### PR TITLE
comment out code for server's --polling-interval flag

### DIFF
--- a/mdz/pkg/cmd/server.go
+++ b/mdz/pkg/cmd/server.go
@@ -29,7 +29,6 @@ func init() {
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
 	serverCmd.PersistentFlags().BoolVarP(&serverVerbose, "verbose", "v", false, "Verbose output")
-	// serverCmd.PersistentFlags().DurationVarP(&serverPollingInterval, "polling-interval", "p", 3*time.Second, "Polling interval")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:


### PR DESCRIPTION
New output from `mdz server -h` with this change:

<img width="834" alt="CleanShot-2023-07-19T12-37-58@2x" src="https://github.com/tensorchord/openmodelz/assets/45612704/15bdf43e-e3f8-400b-a017-75d6a63ef571">

closes #16 
