### PR TITLE
feat: support follow the k8s log

### DIFF
--- a/agent/pkg/log/k8s.go
+++ b/agent/pkg/log/k8s.go
@@ -63,6 +63,9 @@ func (k *K8sAPIRequestor) Query(ctx context.Context,
 		if err != nil {
 			return nil, errdefs.InvalidParameter(err)
 		}
+	} else if r.Follow {
+		// avoid truncate
+		endTime = time.Now().Add(time.Hour)
 	} else {
 		endTime = time.Now()
 	}
@@ -152,7 +155,7 @@ func podLogs(ctx context.Context, i v1.PodInterface, pod, container,
 		opts.SinceSeconds = parseSince(since)
 	}
 
-	stream, err := i.GetLogs(pod, opts).Stream(context.TODO())
+	stream, err := i.GetLogs(pod, opts).Stream(ctx)
 	if err != nil {
 		return err
 	}

--- a/mdz/pkg/cmd/logs.go
+++ b/mdz/pkg/cmd/logs.go
@@ -9,6 +9,7 @@ var (
 	tail  int
 	since string
 	end   string
+	follow bool
 )
 
 // logCmd represents the log command
@@ -36,15 +37,16 @@ func init() {
 	logsCmd.Flags().IntVarP(&tail, "tail", "t", 0, "Number of lines to show from the end of the logs")
 	logsCmd.Flags().StringVarP(&since, "since", "s", "2006-01-02T15:04:05Z", "Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
 	logsCmd.Flags().StringVarP(&end, "end", "e", "", "Only return logs before this timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
+	logsCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow log output")
 }
 
 func commandLogs(cmd *cobra.Command, args []string) error {
-	logs, err := agentClient.DeploymentLogGet(cmd.Context(), namespace, args[0], since, tail, end)
+	logStream, err := agentClient.DeploymentLogGet(cmd.Context(), namespace, args[0], since, tail, end, follow)
 	if err != nil {
 		cmd.PrintErrf("Failed to get logs: %s\n", err)
 		return err
 	}
-	for _, log := range logs {
+	for log := range logStream {
 		cmd.Printf("%s: %s\n", log.Instance, log.Text)
 	}
 	return nil


### PR DESCRIPTION
- close #124 

This PR adds the `mdz logs <name> --follow` argument.