### PR TITLE
build: use build.sh to build mdz

### DIFF
--- a/mdz/.gitignore
+++ b/mdz/.gitignore
@@ -15,6 +15,7 @@
 .idea
 
 bin/
+debug-bin/
 **/password.txt
 **/gateway-password.txt
 

--- a/mdz/Makefile
+++ b/mdz/Makefile
@@ -28,9 +28,6 @@
 # This repo's root import path (under GOPATH).
 ROOT := github.com/tensorchord/openmodelz/mdz
 
-# Target binaries. You can build multiple binaries for a single project.
-TARGETS := mdz
-
 # Container image prefix and suffix added to targets.
 # The final built images are:
 #   $[REGISTRY]/$[IMAGE_PREFIX]$[TARGET]$[IMAGE_SUFFIX]:$[VERSION]
@@ -137,31 +134,23 @@ swag-install:
 	go install github.com/swaggo/swag/cmd/swag@v1.8.7
 
 build-local:
-	@for target in $(TARGETS); do                                                      \
-	  CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -trimpath -v -o $(OUTPUT_DIR)/$${target}     \
-	    -ldflags "-s -w -X $(ROOT)/pkg/version.version=$(VERSION) -X $(ROOT)/pkg/version.buildDate=$(BUILD_DATE) -X $(ROOT)/pkg/version.gitCommit=$(GIT_COMMIT) -X $(ROOT)/pkg/version.gitTreeState=$(GIT_TREE_STATE)"                     \
-	    $(CMD_DIR)/$${target};                                                         \
-	done
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
+	VERSION=$(VERSION) BUILD_DATE=$(BUILD_DATE) \
+	GIT_COMMIT=$(GIT_COMMIT) GIT_TREE_STATE=$(GIT_TREE_STATE) GIT_TAG=$(GIT_TAG) \
+	./hack/build.sh build
 
 build-release:
-	@for target in $(TARGETS); do                                                      \
-	  CGO_ENABLED=$(CGO_ENABLED) go build -trimpath -o $(OUTPUT_DIR)/$${target}     \
-	    -ldflags "-s -w -X $(ROOT)/pkg/version.version=$(VERSION) \
-		-X $(ROOT)/pkg/version.buildDate=$(BUILD_DATE) \
-		-X $(ROOT)/pkg/version.gitCommit=$(GIT_COMMIT) \
-		-X $(ROOT)/pkg/version.gitTreeState=$(GIT_TREE_STATE)                     \
-		-X $(ROOT)/pkg/version.gitTag=$(GIT_TAG)" \
-	    $(CMD_DIR)/$${target};                                                         \
-	done
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
+	VERSION=$(VERSION) BUILD_DATE=$(BUILD_DATE) \
+	GIT_COMMIT=$(GIT_COMMIT) GIT_TREE_STATE=$(GIT_TREE_STATE) GIT_TAG=$(GIT_TAG) \
+	./hack/build.sh release
 
 # It is used by vscode to attach into the process.
 debug-local:
-	@for target in $(TARGETS); do                                                      \
-	  CGO_ENABLED=$(CGO_ENABLED) go build -tags $(DASHBOARD_BUILD) -trimpath                                    \
-	  	-v -o $(DEBUG_DIR)/$${target}                                                  \
-	  	-gcflags='all=-N -l'                                                           \
-	    $(CMD_DIR)/$${target};                                                         \
-	done
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
+	VERSION=$(VERSION) BUILD_DATE=$(BUILD_DATE) \
+	GIT_COMMIT=$(GIT_COMMIT) GIT_TREE_STATE=$(GIT_TREE_STATE) GIT_TAG=$(GIT_TAG) \
+	./hack/build.sh debug local
 
 addlicense: addlicense-install  ## Add license to GO code files
 	addlicense -l mpl -c "TensorChord Inc." $$(find . -type f -name '*.go' | grep -v pkg/docs/docs.go)

--- a/mdz/go.mod
+++ b/mdz/go.mod
@@ -2,8 +2,6 @@ module github.com/tensorchord/openmodelz/mdz
 
 go 1.20
 
-replace github.com/tensorchord/openmodelz/agent => ../agent
-
 require (
 	github.com/cockroachdb/errors v1.10.0
 	github.com/docker/docker v23.0.2+incompatible
@@ -16,11 +14,12 @@ require (
 	github.com/moby/moby v24.0.4+incompatible
 	github.com/moby/term v0.5.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
+	github.com/segmentio/analytics-go/v3 v3.2.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
-	github.com/tensorchord/openmodelz/agent v0.0.0-00010101000000-000000000000
+	github.com/tensorchord/openmodelz/agent v0.0.0-20230808082244-c23067f08183
 	github.com/toorop/gin-logrus v0.0.0-20210225092905-2c785434f26f
 	golang.org/x/term v0.8.0
 	k8s.io/apimachinery v0.27.3
@@ -30,6 +29,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
@@ -70,7 +70,6 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/segmentio/analytics-go/v3 v3.2.1 // indirect
 	github.com/segmentio/backo-go v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/swaggo/swag v1.8.12 // indirect
@@ -86,4 +85,5 @@ require (
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools/v3 v3.5.0 // indirect
 )

--- a/mdz/go.sum
+++ b/mdz/go.sum
@@ -4,6 +4,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
@@ -79,6 +81,7 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -184,6 +187,8 @@ github.com/swaggo/gin-swagger v1.6.0 h1:y8sxvQ3E20/RCyrXeFfg60r6H0Z+SwpTjMYsMm+z
 github.com/swaggo/gin-swagger v1.6.0/go.mod h1:BG00cCEy294xtVpyIAHG6+e2Qzj/xKlRdOqDkvq0uzo=
 github.com/swaggo/swag v1.8.12 h1:pctzkNPu0AlQP2royqX3apjKCQonAnf7KGoxeO4y64w=
 github.com/swaggo/swag v1.8.12/go.mod h1:lNfm6Gg+oAq3zRJQNEMBE66LIJKM44mxFqhEEgy2its=
+github.com/tensorchord/openmodelz/agent v0.0.0-20230808082244-c23067f08183 h1:V83LJwdkoPoVK3gxyyhnVGTAO1ck+ysYtFZNf98ZUkc=
+github.com/tensorchord/openmodelz/agent v0.0.0-20230808082244-c23067f08183/go.mod h1:FlQm4KSpFRY4q8FzlHJRJ0xchvzaFaI891MXmJoXmh8=
 github.com/toorop/gin-logrus v0.0.0-20210225092905-2c785434f26f h1:oqdnd6OGlOUu1InG37hWcCB3a+Jy3fwjylyVboaNMwY=
 github.com/toorop/gin-logrus v0.0.0-20210225092905-2c785434f26f/go.mod h1:X3Dd1SB8Gt1V968NTzpKFjMM6O8ccta2NPC6MprOxZQ=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
@@ -285,7 +290,8 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
+gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
+gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 k8s.io/apimachinery v0.27.3 h1:Ubye8oBufD04l9QnNtW05idcOe9Z3GQN8+7PqmuVcUM=
 k8s.io/apimachinery v0.27.3/go.mod h1:XNfZ6xklnMCOGGFNqXG7bUrQCoR04dh/E7FprV6pb+E=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/mdz/hack/build.sh
+++ b/mdz/hack/build.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+kind=${1:-"build"}
+deps=${2:-"remote"}
+
+PROJECT_ROOT=$(realpath "$(dirname "${BASH_SOURCE[@]}")/..")
+PROJECT=github.com/tensorchord/openmodelz/mdz
+
+VERSION=${VERSION:-"v0.0.$(date +%Y%m%d)"}
+BUILD_DATE=${BUILD_DATE:-""}
+GIT_COMMIT=${GIT_COMMIT:-""}
+GIT_TREE_STATE=${GIT_TREE_STATE:-""}
+GIT_TAG=${GIT_TAG:-""}
+
+CGO_ENABLED=${CGO_ENABLED:="0"}
+GOOS=${GOOS:="$(go env GOOS)"}
+GOARCH=${GOARCH:="$(go env GOARCH)"}
+
+DASHBOARD_BUILD=${DASHBOARD_BUILD:-"debug"}
+
+OUTPUT_DIR=${OUTPUT_DIR:-"${PROJECT_ROOT}"}
+if [[ ${kind} == "debug" ]]; then
+    OUTPUT_DIR="${OUTPUT_DIR}/debug-bin"
+else
+    OUTPUT_DIR="${OUTPUT_DIR}/bin"
+fi
+
+LDFLAGS="-s -w \
+  -X ${PROJECT}/pkg/version.version=${VERSION} \
+  -X ${PROJECT}/pkg/version.buildDate=${BUILD_DATE} \
+  -X ${PROJECT}/pkg/version.gitCommit=${GIT_COMMIT} \
+  -X ${PROJECT}/pkg/version.gitTreeState=${GIT_TREE_STATE}"
+if [[ ${kind} == "release" ]]; then
+    LDFLAGS="${LDFLAGS} -X ${PROJECT}/pkg/version.gitTag=${GIT_TAG}"
+fi
+
+DEBUG_ARGS=()
+if [[ ${kind} == "debug" ]]; then
+    DEBUG_ARGS=(-tags "${DASHBOARD_BUILD}" -gcflags="all=-N -l")
+fi
+
+MOD_FILE="${PROJECT_ROOT}/go.mod"
+if [[ ${deps} == "local" ]]; then
+    if ! grep "\.\./agent" "${MOD_FILE}"; then
+        echo "replace github.com/tensorchord/openmodelz/agent => ../agent" >> "${MOD_FILE}"
+        go mod tidy
+    fi
+else
+    if grep "\.\./agent" "${MOD_FILE}"; then
+        sed -i -e '/..agent/d' "${MOD_FILE}"
+        go mod tidy
+    fi
+fi
+
+CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build \
+           "${DEBUG_ARGS[@]}" \
+           -trimpath -v \
+           -ldflags "${LDFLAGS}" \
+           -o "${OUTPUT_DIR}/mdz" \
+           "./cmd/mdz"


### PR DESCRIPTION
fix 1/4 of https://github.com/tensorchord/openmodelz/issues/133

Makefile has too much magic, use bash to do the building.

only use local agent dependency for `debug-local`, the others will drop the local dependency and use the latest remote agent.