### PR TITLE
ci: run test when all Makefile changed

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,13 +7,13 @@ on:
     paths:
       - '.github/workflows/**'
       - '**.go'
-      - 'Makefile'
+      - '**/Makefile'
       - 'go.**'
   pull_request:
     paths:
       - '.github/workflows/**'
       - '**.go'
-      - 'Makefile'
+      - '**/Makefile'
       - 'go.**'
 
 concurrency:


### PR DESCRIPTION
should run CI when mdz, agent Makefile changed

ps, CI will fail if upgrade to go 1.20, not yet dug into it, keep it 1.19