### PR TITLE
build: use MDZ_DEPS env var to determine dependencies type

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -70,4 +70,4 @@ jobs:
       - name: mdz
         run: |
           cd ./mdz
-          make
+          MDZ_DEPS=local make

--- a/mdz/Makefile
+++ b/mdz/Makefile
@@ -150,7 +150,7 @@ debug-local:
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
 	VERSION=$(VERSION) BUILD_DATE=$(BUILD_DATE) \
 	GIT_COMMIT=$(GIT_COMMIT) GIT_TREE_STATE=$(GIT_TREE_STATE) GIT_TAG=$(GIT_TAG) \
-	./hack/build.sh debug local
+	./hack/build.sh debug
 
 addlicense: addlicense-install  ## Add license to GO code files
 	addlicense -l mpl -c "TensorChord Inc." $$(find . -type f -name '*.go' | grep -v pkg/docs/docs.go)

--- a/mdz/hack/build.sh
+++ b/mdz/hack/build.sh
@@ -6,7 +6,7 @@ set -o nounset
 set -o pipefail
 
 kind=${1:-"build"}
-deps=${2:-"remote"}
+deps=${MDZ_DEPS:-"remote"}
 
 PROJECT_ROOT=$(realpath "$(dirname "${BASH_SOURCE[@]}")/..")
 PROJECT=github.com/tensorchord/openmodelz/mdz


### PR DESCRIPTION
this is how I propose the new solution for local dependencies.

As before, I believe local dependencies should not be in-tree for Go.

this PR added and env variable `MDZ_DEPS` which could be `local`, and could be used by 

```sh
export MDZ_DEPS=local
make
```

or

```sh
MDZ_DEPS=local make
```

which will change the agent dependency to local `../agent` when building, and we can still keep the versioned dependency in-tree.

for local development, we can `export MDZ_DEPS` in shell, and it will use local dependencies automatically every time we build in this shell.