### PR TITLE
feat: log pod start time

### DIFF
--- a/agent/api/types/const.go
+++ b/agent/api/types/const.go
@@ -1,6 +1,0 @@
-package types
-
-const (
-	LabelNamespace      = "modelz.tensorchord.ai/namespace"
-	LabelServerResource = "ai.tensorchord.server-resource"
-)

--- a/agent/api/types/event.go
+++ b/agent/api/types/event.go
@@ -3,12 +3,15 @@ package types
 import "time"
 
 const (
-	DeploymentCreateEvent     = "deployment-create"
-	DeploymentUpdateEvent     = "deployment-update"
-	DeploymentDeleteEvent     = "deployment-delete"
-	DeploymentScaleUpEvent    = "deployment-scale-up"
-	DeploymentScaleDownEvent  = "deployment-scale-down"
-	DeploymentScaleBlockEvent = "deployment-scale-block"
+	DeploymentCreateEvent       = "deployment-create"
+	DeploymentUpdateEvent       = "deployment-update"
+	DeploymentDeleteEvent       = "deployment-delete"
+	DeploymentScaleUpEvent      = "deployment-scale-up"
+	DeploymentScaleDownEvent    = "deployment-scale-down"
+	DeploymentScaleBlockEvent   = "deployment-scale-block"
+	DeploymentStartBeginEvent   = "deployment-start-begin"
+	DeploymentStartFinishEvent  = "deployment-start-finish"
+	DeploymentStartTimeoutEvent = "deployment-start-timeout"
 )
 
 type DeploymentEvent struct {

--- a/agent/api/types/event.go
+++ b/agent/api/types/event.go
@@ -3,15 +3,15 @@ package types
 import "time"
 
 const (
-	DeploymentCreateEvent       = "deployment-create"
-	DeploymentUpdateEvent       = "deployment-update"
-	DeploymentDeleteEvent       = "deployment-delete"
-	DeploymentScaleUpEvent      = "deployment-scale-up"
-	DeploymentScaleDownEvent    = "deployment-scale-down"
-	DeploymentScaleBlockEvent   = "deployment-scale-block"
-	DeploymentStartBeginEvent   = "deployment-start-begin"
-	DeploymentStartFinishEvent  = "deployment-start-finish"
-	DeploymentStartTimeoutEvent = "deployment-start-timeout"
+	DeploymentCreateEvent     = "deployment-create"
+	DeploymentUpdateEvent     = "deployment-update"
+	DeploymentDeleteEvent     = "deployment-delete"
+	DeploymentScaleUpEvent    = "deployment-scale-up"
+	DeploymentScaleDownEvent  = "deployment-scale-down"
+	DeploymentScaleBlockEvent = "deployment-scale-block"
+	PodCreateEvent            = "pod-create"
+	PodReadyEvent             = "pod-ready"
+	PodTimeoutEvent           = "pod-timeout"
 )
 
 type DeploymentEvent struct {

--- a/agent/pkg/consts/consts.go
+++ b/agent/pkg/consts/consts.go
@@ -3,12 +3,6 @@ package consts
 import "time"
 
 const (
-	LabelBuildName            = "ai.tensorchord.build"
-	LabelName                 = "ai.tensorchord.name"
-	LabelServerResource       = "ai.tensorchord.server-resource"
-	AnnotationControlPlaneKey = "ai.tensorchord.control-plane"
-	ModelzAnnotationValue     = "modelz"
-
 	Domain        = "modelz.live"
 	DefaultPrefix = "modelz-"
 	APIKEY_PREFIX = "mzi-"

--- a/agent/pkg/k8s/generate_image_cache.go
+++ b/agent/pkg/k8s/generate_image_cache.go
@@ -5,8 +5,8 @@ import (
 
 	kubefledged "github.com/senthilrch/kube-fledged/pkg/apis/kubefledged/v1alpha3"
 	"github.com/tensorchord/openmodelz/agent/api/types"
-	"github.com/tensorchord/openmodelz/agent/pkg/consts"
 	modelzetes "github.com/tensorchord/openmodelz/modelzetes/pkg/apis/modelzetes/v2alpha1"
+	"github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/agent/pkg/k8s/generate_job.go
+++ b/agent/pkg/k8s/generate_job.go
@@ -10,9 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/tensorchord/openmodelz/agent/api/types"
-	"github.com/tensorchord/openmodelz/agent/pkg/consts"
 	"github.com/tensorchord/openmodelz/modelzetes/pkg/apis/modelzetes/v2alpha1"
-	mzconsts "github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
+	"github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
 )
 
 func MakeBuild(req types.Build, inference *v2alpha1.Inference, builderImage, buildkitdAddr, buildctlBin, secret string) (*batchv1.Job, error) {
@@ -70,8 +69,8 @@ func MakeBuild(req types.Build, inference *v2alpha1.Inference, builderImage, bui
 			Namespace:       req.Spec.Namespace,
 			OwnerReferences: ownerReference,
 			Labels: map[string]string{
-				consts.LabelBuildName:       req.Spec.Name,
-				mzconsts.AnnotationBuilding: "true",
+				consts.LabelBuildName:     req.Spec.Name,
+				consts.AnnotationBuilding: "true",
 			},
 		},
 		Spec: batchv1.JobSpec{

--- a/agent/pkg/metrics/exporter.go
+++ b/agent/pkg/metrics/exporter.go
@@ -55,6 +55,8 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.metricOptions.ServiceAvailableReplicasGauge.Reset()
 	e.metricOptions.ServiceTargetLoad.Reset()
 
+	e.metricOptions.PodStartHistogram.Collect(ch)
+
 	for _, service := range e.services {
 		var serviceName string
 		if len(service.Spec.Namespace) > 0 {

--- a/agent/pkg/metrics/metrics.go
+++ b/agent/pkg/metrics/metrics.go
@@ -21,6 +21,8 @@ type MetricOptions struct {
 	ServiceReplicasGauge          *prometheus.GaugeVec
 	ServiceAvailableReplicasGauge *prometheus.GaugeVec
 	ServiceTargetLoad             *prometheus.GaugeVec
+
+	PodStartHistogram *prometheus.HistogramVec
 }
 
 // ServiceMetricOptions provides RED metrics
@@ -108,6 +110,12 @@ func BuildMetricsOptions() MetricOptions {
 		[]string{"inference_name"},
 	)
 
+	podStartHistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "pod_start_seconds",
+		Help:    "Pod start time taken",
+		Buckets: []float64{5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 150.0, 300.0},
+	}, []string{"inference_name", "source_image"})
+
 	metricsOptions := MetricOptions{
 		GatewayInferencesHistogram:         gatewayInferencesHistogram,
 		GatewayInferenceInvocation:         gatewayInferenceInvocation,
@@ -116,6 +124,7 @@ func BuildMetricsOptions() MetricOptions {
 		ServiceTargetLoad:                  serviceTargetLoad,
 		GatewayInferenceInvocationStarted:  gatewayInferenceInvocationStarted,
 		GatewayInferenceInvocationInflight: gatewayInferenceInvocationInflight,
+		PodStartHistogram:                  podStartHistogram,
 	}
 
 	return metricsOptions

--- a/agent/pkg/metrics/metrics.go
+++ b/agent/pkg/metrics/metrics.go
@@ -113,7 +113,7 @@ func BuildMetricsOptions() MetricOptions {
 	podStartHistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "pod_start_seconds",
 		Help:    "Pod start time taken",
-		Buckets: []float64{5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 150.0, 300.0},
+		Buckets: prometheus.ExponentialBuckets(8, 1.5, 10),
 	}, []string{"inference_name", "source_image"})
 
 	metricsOptions := MetricOptions{

--- a/agent/pkg/runtime/inference_create.go
+++ b/agent/pkg/runtime/inference_create.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	localconsts "github.com/tensorchord/openmodelz/agent/pkg/consts"
-	ingressv1 "github.com/tensorchord/openmodelz/ingress-operator/pkg/apis/modelzetes/v1"
-	v2alpha1 "github.com/tensorchord/openmodelz/modelzetes/pkg/apis/modelzetes/v2alpha1"
-	"github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +11,10 @@ import (
 	"github.com/tensorchord/openmodelz/agent/api/types"
 	"github.com/tensorchord/openmodelz/agent/errdefs"
 	"github.com/tensorchord/openmodelz/agent/pkg/config"
+	localconsts "github.com/tensorchord/openmodelz/agent/pkg/consts"
+	ingressv1 "github.com/tensorchord/openmodelz/ingress-operator/pkg/apis/modelzetes/v1"
+	v2alpha1 "github.com/tensorchord/openmodelz/modelzetes/pkg/apis/modelzetes/v2alpha1"
+	"github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
 )
 
 func (r generalRuntime) InferenceCreate(ctx context.Context,

--- a/agent/pkg/runtime/inference_create.go
+++ b/agent/pkg/runtime/inference_create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	localconsts "github.com/tensorchord/openmodelz/agent/pkg/consts"
 	ingressv1 "github.com/tensorchord/openmodelz/ingress-operator/pkg/apis/modelzetes/v1"
 	v2alpha1 "github.com/tensorchord/openmodelz/modelzetes/pkg/apis/modelzetes/v2alpha1"
 	"github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
@@ -14,7 +15,6 @@ import (
 	"github.com/tensorchord/openmodelz/agent/api/types"
 	"github.com/tensorchord/openmodelz/agent/errdefs"
 	"github.com/tensorchord/openmodelz/agent/pkg/config"
-	localconsts "github.com/tensorchord/openmodelz/agent/pkg/consts"
 )
 
 func (r generalRuntime) InferenceCreate(ctx context.Context,
@@ -37,7 +37,7 @@ func (r generalRuntime) InferenceCreate(ctx context.Context,
 	// Create the ingress
 	// TODO(gaocegege): Check if the domain is already used.
 	if r.ingressEnabled {
-		name := req.Spec.Labels[localconsts.LabelName]
+		name := req.Spec.Labels[consts.LabelName]
 
 		if r.ingressAnyIPToDomain {
 			// Get the service with type=loadbalancer.
@@ -208,8 +208,8 @@ func makeIngress(request types.InferenceDeployment, cfg config.IngressConfig) (*
 	}
 
 	annotation := map[string]string{}
-	if value, exist := request.Spec.Annotations[localconsts.AnnotationControlPlaneKey]; exist {
-		annotation[localconsts.AnnotationControlPlaneKey] = value
+	if value, exist := request.Spec.Annotations[consts.AnnotationControlPlaneKey]; exist {
+		annotation[consts.AnnotationControlPlaneKey] = value
 	}
 	ingress.Annotations = annotation
 

--- a/agent/pkg/runtime/namespace.go
+++ b/agent/pkg/runtime/namespace.go
@@ -8,14 +8,14 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/tensorchord/openmodelz/agent/api/types"
 	"github.com/tensorchord/openmodelz/agent/errdefs"
+	"github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
 )
 
 func (r generalRuntime) NamespaceList(ctx context.Context) ([]string, error) {
 	ns, err := r.kubeClient.CoreV1().Namespaces().List(ctx,
 		metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=true", types.LabelNamespace),
+			LabelSelector: fmt.Sprintf("%s=true", consts.LabelNamespace),
 		})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -37,7 +37,7 @@ func (r generalRuntime) NamespaceCreate(ctx context.Context, name string) error 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				types.LabelNamespace: "true",
+				consts.LabelNamespace: "true",
 			},
 		},
 	}

--- a/agent/pkg/runtime/node.go
+++ b/agent/pkg/runtime/node.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
-	"github.com/tensorchord/openmodelz/agent/pkg/consts"
+	"github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/agent/pkg/runtime/runtime.go
+++ b/agent/pkg/runtime/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/sirupsen/logrus"
 	apicorev1 "k8s.io/api/core/v1"
 	appsv1 "k8s.io/client-go/informers/apps/v1"

--- a/ingress-operator/pkg/consts/consts.go
+++ b/ingress-operator/pkg/consts/consts.go
@@ -1,8 +1,6 @@
 package consts
 
 const (
-	KeyCert                   = "cert"
-	EnvironmentPrefix         = "MODELZ"
-	AnnotationControlPlaneKey = "ai.tensorchord.control-plane"
-	ModelzAnnotationValue     = "modelz"
+	KeyCert           = "cert"
+	EnvironmentPrefix = "MODELZ"
 )

--- a/ingress-operator/pkg/controller/core.go
+++ b/ingress-operator/pkg/controller/core.go
@@ -13,8 +13,7 @@ import (
 	faasscheme "github.com/tensorchord/openmodelz/ingress-operator/pkg/client/clientset/versioned/scheme"
 	v1 "github.com/tensorchord/openmodelz/ingress-operator/pkg/client/informers/externalversions/modelzetes/v1"
 	listers "github.com/tensorchord/openmodelz/ingress-operator/pkg/client/listers/modelzetes/v1"
-	"github.com/tensorchord/openmodelz/ingress-operator/pkg/consts"
-	mdzconsts "github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
+	"github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -257,7 +256,7 @@ func MakeAnnotations(fni *faasv1.InferenceIngress, host string) map[string]strin
 	annotations := make(map[string]string)
 
 	annotations["ai.tensorchord.spec"] = string(specJSON)
-	inferenceNamespace := fni.Labels[mdzconsts.LabelInferenceNamespace]
+	inferenceNamespace := fni.Labels[consts.LabelInferenceNamespace]
 
 	if !fni.Spec.BypassGateway {
 		switch class {

--- a/ingress-operator/pkg/controller/core.go
+++ b/ingress-operator/pkg/controller/core.go
@@ -8,12 +8,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	faasv1 "github.com/tensorchord/openmodelz/ingress-operator/pkg/apis/modelzetes/v1"
-	"github.com/tensorchord/openmodelz/ingress-operator/pkg/client/clientset/versioned/scheme"
-	faasscheme "github.com/tensorchord/openmodelz/ingress-operator/pkg/client/clientset/versioned/scheme"
-	v1 "github.com/tensorchord/openmodelz/ingress-operator/pkg/client/informers/externalversions/modelzetes/v1"
-	listers "github.com/tensorchord/openmodelz/ingress-operator/pkg/client/listers/modelzetes/v1"
-	"github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,6 +20,13 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	klog "k8s.io/klog"
+
+	faasv1 "github.com/tensorchord/openmodelz/ingress-operator/pkg/apis/modelzetes/v1"
+	"github.com/tensorchord/openmodelz/ingress-operator/pkg/client/clientset/versioned/scheme"
+	faasscheme "github.com/tensorchord/openmodelz/ingress-operator/pkg/client/clientset/versioned/scheme"
+	v1 "github.com/tensorchord/openmodelz/ingress-operator/pkg/client/informers/externalversions/modelzetes/v1"
+	listers "github.com/tensorchord/openmodelz/ingress-operator/pkg/client/listers/modelzetes/v1"
+	"github.com/tensorchord/openmodelz/modelzetes/pkg/consts"
 )
 
 const AgentName = "ingress-operator"

--- a/modelzetes/pkg/consts/consts.go
+++ b/modelzetes/pkg/consts/consts.go
@@ -5,8 +5,16 @@ const (
 
 	LabelInferenceName      = "inference"
 	LabelInferenceNamespace = "inference-namespace"
+	LabelBuildName          = "ai.tensorchord.build"
+	LabelName               = "ai.tensorchord.name"
+	LabelNamespace          = "modelz.tensorchord.ai/namespace"
+	LabelServerResource     = "ai.tensorchord.server-resource"
 
-	AnnotationBuilding = "ai.tensorchord.building"
+	AnnotationBuilding        = "ai.tensorchord.building"
+	AnnotationDockerImage     = "ai.tensorchord.docker.image"
+	AnnotationControlPlaneKey = "ai.tensorchord.control-plane"
+
+	ModelzAnnotationValue = "modelz"
 
 	TolerationGPU              = "ai.tensorchord.gpu"
 	TolerationNvidiaGPUPresent = "nvidia.com/gpu"


### PR DESCRIPTION
This is a step to log start time of ModelZ deployment.

# Refactor
- Move all Anotation and Label consts into `modelzetes`.

# Feat
- Add new events: `pod-create`, `pod-ready` and `pod-timeout`
`pod-create` emitted when any pod created
`pod-ready` emitted when the pod is ready
`pod-timeout` emitted when the pod takes more than 5 minutes to start
The `message` of these events is `pod name`
![image](https://github.com/tensorchord/openmodelz/assets/19801166/001f0b1f-9c58-4265-aaf6-4469da2aeb2b)


It could read by `apiserver` to fetch latest pod start time range.

- Add a new `pod_start_seconds` Histogram to Prometheus with Buckets: 
{5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 150.0, 300.0}
It would be observed from one `deployment-start-begin` to `deployment-start-finish`

This could help us to draw a Histogram graph at `modelz-ui -> Observability` for all deployments.